### PR TITLE
ref: Simplify creating producer

### DIFF
--- a/examples/simple_accountant.rs
+++ b/examples/simple_accountant.rs
@@ -2,6 +2,7 @@ extern crate sentry_usage_accountant;
 
 use clap::Parser;
 use sentry_usage_accountant::{KafkaConfig, UsageAccountant, UsageUnit};
+use std::collections::HashMap;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -16,7 +17,10 @@ fn main() {
 
     tracing_subscriber::fmt::init();
 
-    let kafka_config = KafkaConfig::new_producer_config(args.bootstrap_server.as_str(), None);
+    let kafka_config = KafkaConfig::new_producer_config(HashMap::from([(
+        "bootstrap.servers".to_string(),
+        args.bootstrap_server.to_string(),
+    )]));
     let mut accountant = UsageAccountant::new_with_kafka(kafka_config, None, None);
 
     accountant

--- a/examples/simple_produce.rs
+++ b/examples/simple_produce.rs
@@ -2,6 +2,7 @@ extern crate sentry_usage_accountant;
 
 use clap::Parser;
 use sentry_usage_accountant::{KafkaConfig, KafkaProducer, Producer};
+use std::collections::HashMap;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -20,7 +21,10 @@ fn main() {
 
     tracing_subscriber::fmt::init();
 
-    let kafka_config = KafkaConfig::new_producer_config(args.bootstrap_server.as_str(), None);
+    let kafka_config = KafkaConfig::new_producer_config(HashMap::from([(
+        "bootstrap.servers".to_string(),
+        args.bootstrap_server.to_string(),
+    )]));
     let mut producer = KafkaProducer::new(kafka_config);
 
     let _ = producer.send("test_topic", "{a:1}".as_bytes());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,10 @@
 //!
 //! ```
 //! use sentry_usage_accountant::{KafkaConfig, UsageAccountant, UsageUnit};
+//! use std::collections::HashMap;
 //!
 //! let kafka_config = KafkaConfig::new_producer_config(
-//!     "localhost:9092",
-//!     None
+//!     HashMap::from([("bootstrap.servers".to_string(), "localhost:9092".to_string())]),
 //! );
 //! let mut accountant = UsageAccountant::new_with_kafka(
 //!    kafka_config,

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -26,9 +26,7 @@ pub struct KafkaConfig {
 }
 
 impl KafkaConfig {
-    pub fn new_producer_config(
-        config: HashMap<String, String>,
-    ) -> Self {
+    pub fn new_producer_config(config: HashMap<String, String>) -> Self {
         Self { config_map: config }
     }
 }
@@ -133,11 +131,12 @@ mod tests {
     #[test]
     fn test_build_producer_configuration() {
         let config = KafkaConfig::new_producer_config(
-            "localhost:9092",
-            Some(HashMap::from([(
+            HashMap::from([
+                ("bootstrap.servers".to_string(), "localhost:9092".to_string()),
+                (
                 "queued.max.messages.kbytes".to_string(),
                 "1000000".to_string(),
-            )])),
+            )]),
         );
 
         let rdkafka_config: RdKafkaConfig = config.into();

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -27,15 +27,9 @@ pub struct KafkaConfig {
 
 impl KafkaConfig {
     pub fn new_producer_config(
-        bootstrap_servers: &str,
-        override_params: Option<HashMap<String, String>>,
+        config: HashMap<String, String>,
     ) -> Self {
-        let mut config_map: HashMap<String, String> = HashMap::new();
-        config_map.insert("bootstrap.servers".to_string(), bootstrap_servers.into());
-
-        let config = Self { config_map };
-
-        apply_override_params(config, override_params)
+        Self { config_map: config }
     }
 }
 
@@ -47,21 +41,6 @@ impl From<KafkaConfig> for RdKafkaConfig {
         }
         config_obj
     }
-}
-
-fn apply_override_params<V>(
-    mut config: KafkaConfig,
-    override_params: Option<HashMap<String, V>>,
-) -> KafkaConfig
-where
-    V: Into<String>,
-{
-    if let Some(params) = override_params {
-        for (param, value) in params {
-            config.config_map.insert(param, value.into());
-        }
-    }
-    config
 }
 
 struct CaptureErrorContext;

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -130,14 +130,16 @@ mod tests {
 
     #[test]
     fn test_build_producer_configuration() {
-        let config = KafkaConfig::new_producer_config(
-            HashMap::from([
-                ("bootstrap.servers".to_string(), "localhost:9092".to_string()),
-                (
+        let config = KafkaConfig::new_producer_config(HashMap::from([
+            (
+                "bootstrap.servers".to_string(),
+                "localhost:9092".to_string(),
+            ),
+            (
                 "queued.max.messages.kbytes".to_string(),
                 "1000000".to_string(),
-            )]),
-        );
+            ),
+        ]));
 
         let rdkafka_config: RdKafkaConfig = config.into();
         assert_eq!(


### PR DESCRIPTION
In Snuba, we pre-resolve all the producer config (with bootstrap.servers) in Python to share between Rust and Python code. This is to avoid splitting it back out to pass to the accountant.