### PR TITLE
ref(producer): Export ClientError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,4 +58,4 @@ mod producer;
 pub use accountant::UsageAccountant;
 #[doc(inline)]
 pub use accumulator::UsageUnit;
-pub use producer::{KafkaConfig, KafkaProducer, Producer};
+pub use producer::{ClientError, KafkaConfig, KafkaProducer, Producer};


### PR DESCRIPTION
You cannot implement the trait without naming the error