### PR TITLE
ref: Refactor producers, make Kafka optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ documentation = "https://docs.rs/sentry_usage_accountant"
 repository = "https://github.com/getsentry/rust-usage-accountant"
 readme = "README.md"
 
+[features]
+kafka = ["dep:rdkafka"]
+
 [dependencies]
 chrono = "0.4.31"
-rdkafka = ">=0.29.0, <0.37.0"
+rdkafka = { version = ">=0.29.0, <0.37.0", optional = true }
 thiserror = "1.0"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"
@@ -22,3 +25,12 @@ tracing = "0.1.37"
 [dev-dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json", "time"]}
+
+[[example]]
+name = "simple_produce"
+required-features = ["kafka"]
+
+[[example]]
+name = "simple_accountant"
+required-features = ["kafka"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,5 @@ required-features = ["kafka"]
 name = "simple_accountant"
 required-features = ["kafka"]
 
+[package.metadata."docs.rs"]
+all-features = true

--- a/examples/simple_accountant.rs
+++ b/examples/simple_accountant.rs
@@ -17,11 +17,14 @@ fn main() {
 
     tracing_subscriber::fmt::init();
 
-    let kafka_config = KafkaConfig::new_producer_config(HashMap::from([(
-        "bootstrap.servers".to_string(),
-        args.bootstrap_server.to_string(),
-    )]));
-    let mut accountant = UsageAccountant::new_with_kafka(kafka_config, None, None);
+    let kafka_config = KafkaConfig {
+        config: HashMap::from([(
+            "bootstrap.servers".to_string(),
+            args.bootstrap_server.to_string(),
+        )]),
+        ..Default::default()
+    };
+    let mut accountant = UsageAccountant::new_with_kafka(kafka_config, None);
 
     accountant
         .record("my_resource", "my_feature", 100, UsageUnit::Bytes)

--- a/examples/simple_produce.rs
+++ b/examples/simple_produce.rs
@@ -1,7 +1,7 @@
 extern crate sentry_usage_accountant;
 
 use clap::Parser;
-use sentry_usage_accountant::{KafkaConfig, KafkaProducer, Producer, UsageUnit};
+use sentry_usage_accountant::{KafkaConfig, KafkaProducer, Producer};
 use std::collections::HashMap;
 
 #[derive(Parser, Debug)]
@@ -31,12 +31,6 @@ fn main() {
     let mut producer = KafkaProducer::new(kafka_config);
 
     producer
-        .send(sentry_usage_accountant::Message {
-            timestamp: 1337,
-            shared_resource_id: "some_resource".to_owned(),
-            app_feature: "feature".to_owned(),
-            usage_unit: UsageUnit::Bytes,
-            amount: 42,
-        })
+        .send("hello world".as_bytes().to_vec())
         .expect("failed to produce message");
 }

--- a/src/accountant.rs
+++ b/src/accountant.rs
@@ -1,16 +1,14 @@
-use crate::accumulator::{UsageAccumulator, UsageUnit};
-use crate::producer::{ClientError, KafkaConfig, KafkaProducer, Producer};
+use crate::{accumulator::UsageAccumulator, Producer};
+use crate::{Message, UsageUnit};
 use chrono::{Duration, Utc};
-use serde::Serialize;
 use std::ops::Drop;
 
-static DEFAULT_TOPIC_NAME: &str = "shared-resources-usage";
 /// This is the entry point for the library. It is in most cases
 /// everything you need to instrument your application.
 ///
 /// The UsageAccountant needs a `Producer` and a `UsageAccumulator`.
 /// Data is stored in the accumulator and, periodically, it is
-/// flushed into the Kafka topic via a consumer.
+/// flushed into the Producer via a consumer.
 ///
 /// Accumulating data locally is critical to reduce the performance impact
 /// of this library to a minimum and reduce the amount of Kafka messages.
@@ -23,43 +21,30 @@ static DEFAULT_TOPIC_NAME: &str = "shared-resources-usage";
 pub struct UsageAccountant<P: Producer> {
     accumulator: UsageAccumulator,
     producer: P,
-    topic: String,
 }
 
-#[derive(Serialize)]
-struct Message {
-    timestamp: i64,
-    shared_resource_id: String,
-    app_feature: String,
-    usage_unit: UsageUnit,
-    amount: u64,
-}
-
-impl UsageAccountant<KafkaProducer> {
+#[cfg(feature = "kafka")]
+impl UsageAccountant<crate::KafkaProducer> {
     /// Instantiates a UsageAccountant from a Kafka config object.
     /// This initialization method lets the `UsageAccountant` create
     /// the producer and own it.
     ///
     /// You should very rarely change topic name or granularity.
     pub fn new_with_kafka(
-        producer_config: KafkaConfig,
-        topic_name: Option<&str>,
+        producer_config: crate::KafkaConfig,
         granularity: Option<Duration>,
-    ) -> UsageAccountant<KafkaProducer> {
-        UsageAccountant::new(KafkaProducer::new(producer_config), topic_name, granularity)
+    ) -> UsageAccountant<crate::KafkaProducer> {
+        UsageAccountant::new(crate::KafkaProducer::new(producer_config), granularity)
     }
 }
 
 impl<P: Producer> UsageAccountant<P> {
     /// Instantiates a UsageAccountant by leaving the responsibility
     /// to provide a producer to the client.
-    pub fn new(producer: P, topic_name: Option<&str>, granularity: Option<Duration>) -> Self {
-        let topic = topic_name.unwrap_or(DEFAULT_TOPIC_NAME).to_string();
-
+    pub fn new(producer: P, granularity: Option<Duration>) -> Self {
         UsageAccountant {
             accumulator: UsageAccumulator::new(granularity),
             producer,
-            topic,
         }
     }
 
@@ -73,7 +58,7 @@ impl<P: Producer> UsageAccountant<P> {
         app_feature: &str,
         amount: u64,
         unit: UsageUnit,
-    ) -> Result<(), ClientError> {
+    ) -> Result<(), P::Error> {
         let current_time = Utc::now();
         self.accumulator
             .record(current_time, resource_id, app_feature, amount, unit);
@@ -87,7 +72,7 @@ impl<P: Producer> UsageAccountant<P> {
     ///
     /// This method is called automatically when the Accountant
     /// goes out of scope.
-    fn flush(&mut self) -> Result<(), ClientError> {
+    pub fn flush(&mut self) -> Result<(), P::Error> {
         let flushed_content = self.accumulator.flush();
         for (key, amount) in flushed_content {
             let message = Message {
@@ -98,9 +83,7 @@ impl<P: Producer> UsageAccountant<P> {
                 amount,
             };
 
-            if let Ok(msg) = serde_json::to_string(&message) {
-                self.producer.send(self.topic.as_str(), msg.as_bytes())?;
-            }
+            self.producer.send(message)?;
         }
         Ok(())
     }
@@ -114,34 +97,22 @@ impl<P: Producer> Drop for UsageAccountant<P> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::accumulator::UsageUnit;
-    use super::super::producer::DummyProducer;
-    use super::UsageAccountant;
-    use serde_json::Value;
-    use std::cell::RefCell;
-    use std::rc::Rc;
-    use std::str::from_utf8;
+    use crate::{DummyProducer, UsageUnit};
+
+    use super::*;
 
     #[test]
     fn test_empty_batch() {
-        let messages = Rc::new(RefCell::new(Vec::new()));
-        let producer = DummyProducer {
-            messages: Rc::clone(&messages),
-        };
-        let mut accountant = UsageAccountant::new(producer, None, None);
+        let mut accountant = UsageAccountant::new(DummyProducer::default(), None);
 
         let res = accountant.flush();
         assert!(res.is_ok());
-        assert_eq!(messages.borrow().len(), 0);
+        assert_eq!(accountant.producer.messages.len(), 0);
     }
 
     #[test]
     fn test_three_messages() {
-        let messages = Rc::new(RefCell::new(Vec::new()));
-        let producer = DummyProducer {
-            messages: Rc::clone(&messages),
-        };
-        let mut accountant = UsageAccountant::new(producer, None, None);
+        let mut accountant = UsageAccountant::new(DummyProducer::default(), None);
 
         let res1 = accountant.record("resource_1", "transactions", 100, UsageUnit::Bytes);
         assert!(res1.is_ok());
@@ -150,34 +121,31 @@ mod tests {
 
         let res = accountant.flush();
         assert!(res.is_ok());
-        let messages_vec = messages.borrow();
-        assert_eq!(messages_vec.len(), 2);
 
-        let topic = messages_vec[0].0.clone();
-        assert_eq!(topic, "shared-resources-usage");
-        let payload1 = from_utf8(&(messages_vec[0].1)).unwrap();
-        let m1: Value = serde_json::from_str(payload1).unwrap();
-        assert_eq!(m1["shared_resource_id"], "resource_1".to_string());
-        assert_eq!(m1["usage_unit"], "bytes".to_string());
+        let messages = &accountant.producer.messages;
+        assert_eq!(messages.len(), 2);
 
-        let payload2 = from_utf8(&(messages_vec[1].1)).unwrap();
-        let m2: Value = serde_json::from_str(payload2).unwrap();
-        assert_eq!(m2["shared_resource_id"], "resource_1".to_string());
-        assert_eq!(m2["usage_unit"], "bytes".to_string());
+        let m1 = &messages[0];
+        assert_eq!(m1.shared_resource_id, "resource_1");
+        assert_eq!(m1.usage_unit, UsageUnit::Bytes);
+
+        let m2 = &messages[2];
+        assert_eq!(m2.shared_resource_id, "resource_1");
+        assert_eq!(m2.usage_unit, UsageUnit::Bytes);
 
         // The messages will not necessarily be in order.
-        assert_ne!(m1["app_feature"], m2["app_feature"]);
-        if m1["app_feature"] == "transactions" {
-            assert_eq!(m2["app_feature"], "spans".to_string())
+        assert_ne!(m1.app_feature, m2.app_feature);
+        if m1.app_feature == "transactions" {
+            assert_eq!(m2.app_feature, "spans")
         } else {
-            assert_eq!(m2["app_feature"], "transactions".to_string());
-            assert_eq!(m1["app_feature"], "spans".to_string());
+            assert_eq!(m2.app_feature, "transactions");
+            assert_eq!(m1.app_feature, "spans");
         }
-        assert_ne!(m1["amount"], m2["amount"]);
+        assert_ne!(m1.amount, m2.amount);
 
         let res = accountant.flush();
         assert!(res.is_ok());
         // Messages are still the same we had before the previous step.
-        assert_eq!(messages.borrow().len(), 2);
+        assert_eq!(accountant.producer.messages.len(), 2);
     }
 }

--- a/src/accountant.rs
+++ b/src/accountant.rs
@@ -129,7 +129,7 @@ mod tests {
         assert_eq!(m1.shared_resource_id, "resource_1");
         assert_eq!(m1.usage_unit, UsageUnit::Bytes);
 
-        let m2 = &messages[2];
+        let m2 = &messages[1];
         assert_eq!(m2.shared_resource_id, "resource_1");
         assert_eq!(m2.usage_unit, UsageUnit::Bytes);
 

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -6,30 +6,10 @@
 //!
 
 use chrono::{DateTime, Duration, DurationRound, Utc};
-use serde::Serialize;
 use std::collections::HashMap;
-use std::fmt;
 use std::mem;
 
-/// The unit of measures we support when recording usage.
-/// more can be added.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum UsageUnit {
-    Milliseconds,
-    Bytes,
-    BytesSec,
-}
-
-impl fmt::Display for UsageUnit {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            UsageUnit::Milliseconds => write!(f, "milliseconds"),
-            UsageUnit::Bytes => write!(f, "bytes"),
-            UsageUnit::BytesSec => write!(f, "bytes_sec"),
-        }
-    }
-}
+use crate::UsageUnit;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct UsageKey {

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 use tracing::{event, Level};
 
-use crate::{Message, Producer};
+use crate::Producer;
 
 const DEFAULT_TOPIC_NAME: &str = "shared-resources-usage";
 
@@ -90,9 +90,7 @@ pub enum KafkaProducerError {
 impl Producer for KafkaProducer {
     type Error = KafkaProducerError;
 
-    fn send(&mut self, message: Message) -> Result<(), Self::Error> {
-        // SAFETY: Serializing to JSON cannot fail. The type will always correctly serialize.
-        let payload = serde_json::to_vec(&message).unwrap();
+    fn send(&mut self, payload: Vec<u8>) -> Result<(), Self::Error> {
         let record: BaseRecord<'_, [u8], [u8]> = BaseRecord::to(&self.topic).payload(&payload);
         self.producer
             .send(record)

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -1,0 +1,129 @@
+use rdkafka::config::ClientConfig as RdKafkaConfig;
+use rdkafka::producer::{BaseRecord, ThreadedProducer};
+use rdkafka::producer::{DeliveryResult, ProducerContext};
+use rdkafka::ClientContext;
+use std::collections::HashMap;
+use thiserror::Error;
+use tracing::{event, Level};
+
+use crate::{Message, Producer};
+
+const DEFAULT_TOPIC_NAME: &str = "shared-resources-usage";
+
+/// This structure wraps the parameters to initialize a producer.
+/// This struct is there in order not to expose the rdkafka
+/// details outside.
+#[derive(Debug, Clone)]
+pub struct KafkaConfig {
+    pub topic: String,
+    pub config: HashMap<String, String>,
+}
+
+impl Default for KafkaConfig {
+    fn default() -> Self {
+        Self {
+            topic: DEFAULT_TOPIC_NAME.to_owned(),
+            config: HashMap::new(),
+        }
+    }
+}
+
+impl From<&KafkaConfig> for RdKafkaConfig {
+    fn from(item: &KafkaConfig) -> Self {
+        let mut config_obj = RdKafkaConfig::new();
+        for (key, val) in item.config.iter() {
+            config_obj.set(key, val);
+        }
+        config_obj
+    }
+}
+
+struct CaptureErrorContext;
+
+impl ClientContext for CaptureErrorContext {}
+
+impl ProducerContext for CaptureErrorContext {
+    type DeliveryOpaque = ();
+
+    fn delivery(&self, result: &DeliveryResult, _delivery_opaque: Self::DeliveryOpaque) {
+        match result {
+            Ok(_) => {
+                event!(Level::DEBUG, "Message produced.")
+            }
+            Err((kafka_err, _)) => {
+                event!(Level::ERROR, "Message production failed. {}", kafka_err)
+            }
+        }
+    }
+}
+
+pub struct KafkaProducer {
+    topic: String,
+    producer: ThreadedProducer<CaptureErrorContext>,
+}
+
+impl KafkaProducer {
+    pub fn new(config: KafkaConfig) -> KafkaProducer {
+        let producer = RdKafkaConfig::from(&config)
+            .create_with_context(CaptureErrorContext)
+            .expect("Producer creation error");
+
+        KafkaProducer {
+            topic: config.topic,
+            producer,
+        }
+    }
+}
+
+/// Kafka producer errors.
+#[derive(Error, Debug)]
+pub enum KafkaProducerError {
+    /// Failed to send a kafka message.
+    #[error("failed to send kafka message")]
+    SendFailed(#[source] rdkafka::error::KafkaError),
+
+    /// Failed to create a kafka producer because of the invalid configuration.
+    #[error("failed to create kafka producer: invalid kafka config")]
+    InvalidConfig(#[source] rdkafka::error::KafkaError),
+}
+
+impl Producer for KafkaProducer {
+    type Error = KafkaProducerError;
+
+    fn send(&mut self, message: Message) -> Result<(), Self::Error> {
+        // SAFETY: Serializing to JSON cannot fail. The type will always correctly serialize.
+        let payload = serde_json::to_vec(&message).unwrap();
+        let record: BaseRecord<'_, [u8], [u8]> = BaseRecord::to(&self.topic).payload(&payload);
+        self.producer
+            .send(record)
+            .map_err(|(error, _message)| KafkaProducerError::SendFailed(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_producer_configuration() {
+        let config = KafkaConfig {
+            config: HashMap::from([
+                (
+                    "bootstrap.servers".to_string(),
+                    "localhost:9092".to_string(),
+                ),
+                (
+                    "queued.max.messages.kbytes".to_string(),
+                    "1000000".to_string(),
+                ),
+            ]),
+            ..Default::default()
+        };
+
+        let rdkafka_config = RdKafkaConfig::from(&config);
+        assert_eq!(
+            rdkafka_config.get("queued.max.messages.kbytes"),
+            Some("1000000")
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,12 @@
 
 pub mod accountant;
 mod accumulator;
+#[cfg(feature = "kafka")]
+mod kafka;
 mod producer;
 
 pub use accountant::UsageAccountant;
+#[cfg(feature = "kafka")]
+pub use kafka::*;
 #[doc(inline)]
-pub use accumulator::UsageUnit;
-pub use producer::{KafkaConfig, KafkaProducer, Producer};
+pub use producer::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
+//! # #[cfg(feature = "kafka")] {
 //! use sentry_usage_accountant::{KafkaConfig, UsageAccountant, UsageUnit};
 //! use std::collections::HashMap;
 //!
@@ -48,6 +49,7 @@
 //!    100,
 //!    UsageUnit::Bytes,
 //! ).unwrap();
+//! # }
 //! ```
 //!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,13 +53,13 @@
 //! ```
 //!
 
-pub mod accountant;
+mod accountant;
 mod accumulator;
 #[cfg(feature = "kafka")]
 mod kafka;
 mod producer;
 
-pub use accountant::UsageAccountant;
+pub use accountant::*;
 #[cfg(feature = "kafka")]
 pub use kafka::*;
 #[doc(inline)]

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -105,7 +105,7 @@ mod tests {
         assert_eq!(shared_resource_id, "foo");
         assert_eq!(app_feature, "app_feature");
         assert!(matches!(usage_unit, UsageUnit::Bytes));
-        assert_eq!(amount, 1337);
+        assert_eq!(amount, 42);
     }
 
     #[test]

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -5,158 +5,92 @@
 //!
 //! It also simplify unit tests.
 
-use rdkafka::config::ClientConfig as RdKafkaConfig;
-use rdkafka::producer::{BaseRecord, ThreadedProducer};
-use rdkafka::producer::{DeliveryResult, ProducerContext};
-use rdkafka::ClientContext;
-#[cfg(test)]
-use std::cell::RefCell;
-use std::collections::HashMap;
-#[cfg(test)]
-use std::rc::Rc;
-use thiserror::Error;
-use tracing::{event, Level};
+use serde::Serialize;
+use std::fmt;
 
-/// This structure wraps the parameters to initialize a producer.
-/// This struct is there in order not to expose the rdkafka
-/// details outside.
-#[derive(Debug, Clone)]
-pub struct KafkaConfig {
-    config_map: HashMap<String, String>,
+#[derive(Serialize, Debug)]
+pub struct Message {
+    pub timestamp: i64,
+    pub shared_resource_id: String,
+    pub app_feature: String,
+    pub usage_unit: UsageUnit,
+    pub amount: u64,
 }
 
-impl KafkaConfig {
-    pub fn new_producer_config(config: HashMap<String, String>) -> Self {
-        Self { config_map: config }
-    }
+/// The unit of measures we support when recording usage.
+/// more can be added.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageUnit {
+    Milliseconds,
+    Bytes,
+    BytesSec,
 }
 
-impl From<KafkaConfig> for RdKafkaConfig {
-    fn from(item: KafkaConfig) -> Self {
-        let mut config_obj = RdKafkaConfig::new();
-        for (key, val) in item.config_map.iter() {
-            config_obj.set(key, val);
-        }
-        config_obj
-    }
-}
-
-struct CaptureErrorContext;
-
-impl ClientContext for CaptureErrorContext {}
-
-impl ProducerContext for CaptureErrorContext {
-    type DeliveryOpaque = ();
-
-    fn delivery(&self, result: &DeliveryResult, _delivery_opaque: Self::DeliveryOpaque) {
-        match result {
-            Ok(_) => {
-                event!(Level::DEBUG, "Message produced.")
-            }
-            Err((kafka_err, _)) => {
-                event!(Level::ERROR, "Message production failed. {}", kafka_err)
-            }
+impl fmt::Display for UsageUnit {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            UsageUnit::Milliseconds => write!(f, "milliseconds"),
+            UsageUnit::Bytes => write!(f, "bytes"),
+            UsageUnit::BytesSec => write!(f, "bytes_sec"),
         }
     }
 }
 
-/// Kafka producer errors.
-#[derive(Error, Debug)]
-pub enum ClientError {
-    /// Failed to send a kafka message.
-    #[error("failed to send kafka message")]
-    SendFailed(#[source] rdkafka::error::KafkaError),
-
-    /// Failed to create a kafka producer because of the invalid configuration.
-    #[error("failed to create kafka producer: invalid kafka config")]
-    InvalidConfig(#[source] rdkafka::error::KafkaError),
-}
-
-/// A basic Kafka Producer trait.
+/// A Producer trait.
 ///
 /// We do not neet to set headers or key for this data.
 pub trait Producer {
-    fn send(&mut self, topic_name: &str, payload: &[u8]) -> Result<(), ClientError>;
-}
+    type Error;
 
-pub struct KafkaProducer {
-    producer: ThreadedProducer<CaptureErrorContext>,
-}
-
-impl KafkaProducer {
-    pub fn new(config: KafkaConfig) -> KafkaProducer {
-        let producer_config: RdKafkaConfig = config.into();
-        KafkaProducer {
-            producer: producer_config
-                .create_with_context(CaptureErrorContext)
-                .expect("Producer creation error"),
-        }
-    }
-}
-
-impl Producer for KafkaProducer {
-    fn send(&mut self, topic_name: &str, payload: &[u8]) -> Result<(), ClientError> {
-        let record: BaseRecord<'_, [u8], [u8]> = BaseRecord::to(topic_name).payload(payload);
-        self.producer
-            .send(record)
-            .map_err(|(error, _message)| ClientError::SendFailed(error))
-    }
+    fn send(&mut self, payload: Message) -> Result<(), Self::Error>;
 }
 
 #[cfg(test)]
+#[derive(Debug, Default)]
 pub(crate) struct DummyProducer {
-    pub messages: Rc<RefCell<Vec<(String, Vec<u8>)>>>,
+    pub messages: Vec<Message>,
 }
 
 #[cfg(test)]
 impl Producer for DummyProducer {
-    fn send(&mut self, topic_name: &str, payload: &[u8]) -> Result<(), ClientError> {
-        self.messages
-            .borrow_mut()
-            .push((topic_name.to_string(), payload.to_vec()));
+    type Error = std::convert::Infallible;
+
+    fn send(&mut self, message: Message) -> Result<(), Self::Error> {
+        self.messages.push(message);
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::DummyProducer;
-    use super::KafkaConfig;
-    use super::Producer;
-    use rdkafka::config::ClientConfig as RdKafkaConfig;
-    use std::cell::RefCell;
-    use std::collections::HashMap;
-    use std::rc::Rc;
-
-    #[test]
-    fn test_build_producer_configuration() {
-        let config = KafkaConfig::new_producer_config(HashMap::from([
-            (
-                "bootstrap.servers".to_string(),
-                "localhost:9092".to_string(),
-            ),
-            (
-                "queued.max.messages.kbytes".to_string(),
-                "1000000".to_string(),
-            ),
-        ]));
-
-        let rdkafka_config: RdKafkaConfig = config.into();
-        assert_eq!(
-            rdkafka_config.get("queued.max.messages.kbytes"),
-            Some("1000000")
-        );
-    }
+    use super::*;
 
     #[test]
     fn test_dummy_producer() {
-        let messages = Rc::new(RefCell::new(Vec::new()));
-        let mut producer = DummyProducer {
-            messages: Rc::clone(&messages),
-        };
-        let res = producer.send("topic", "message".as_bytes());
-        assert!(res.is_ok());
+        let mut producer = DummyProducer::default();
 
-        assert_eq!(producer.messages.borrow().len(), 1);
+        let message = Message {
+            timestamp: 1337,
+            shared_resource_id: "foo".to_owned(),
+            app_feature: "app_feature".to_owned(),
+            usage_unit: UsageUnit::Bytes,
+            amount: 42,
+        };
+        producer.send(message).unwrap();
+
+        let Message {
+            timestamp,
+            shared_resource_id,
+            app_feature,
+            usage_unit,
+            amount,
+        } = producer.messages.pop().unwrap();
+
+        assert_eq!(timestamp, 1337);
+        assert_eq!(shared_resource_id, "foo");
+        assert_eq!(app_feature, "app_feature");
+        assert!(matches!(usage_unit, UsageUnit::Bytes));
+        assert_eq!(amount, 1337);
     }
 }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -5,45 +5,13 @@
 //!
 //! It also simplify unit tests.
 
-use serde::Serialize;
-use std::fmt;
-
-#[derive(Serialize, Debug)]
-pub struct Message {
-    pub timestamp: i64,
-    pub shared_resource_id: String,
-    pub app_feature: String,
-    pub usage_unit: UsageUnit,
-    pub amount: u64,
-}
-
-/// The unit of measures we support when recording usage.
-/// more can be added.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum UsageUnit {
-    Milliseconds,
-    Bytes,
-    BytesSec,
-}
-
-impl fmt::Display for UsageUnit {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            UsageUnit::Milliseconds => write!(f, "milliseconds"),
-            UsageUnit::Bytes => write!(f, "bytes"),
-            UsageUnit::BytesSec => write!(f, "bytes_sec"),
-        }
-    }
-}
-
 /// A Producer trait.
 ///
 /// We do not neet to set headers or key for this data.
 pub trait Producer {
     type Error;
 
-    fn send(&mut self, payload: Message) -> Result<(), Self::Error>;
+    fn send(&mut self, payload: Vec<u8>) -> Result<(), Self::Error>;
 }
 
 impl<T, P> Producer for T
@@ -53,23 +21,23 @@ where
 {
     type Error = P::Error;
 
-    fn send(&mut self, message: Message) -> Result<(), Self::Error> {
-        (**self).send(message)
+    fn send(&mut self, payload: Vec<u8>) -> Result<(), Self::Error> {
+        (**self).send(payload)
     }
 }
 
 #[cfg(test)]
 #[derive(Debug, Default)]
 pub(crate) struct DummyProducer {
-    pub messages: Vec<Message>,
+    pub messages: Vec<Vec<u8>>,
 }
 
 #[cfg(test)]
 impl Producer for DummyProducer {
     type Error = std::convert::Infallible;
 
-    fn send(&mut self, message: Message) -> Result<(), Self::Error> {
-        self.messages.push(message);
+    fn send(&mut self, payload: Vec<u8>) -> Result<(), Self::Error> {
+        self.messages.push(payload);
         Ok(())
     }
 }
@@ -84,28 +52,10 @@ mod tests {
     fn test_dummy_producer() {
         let mut producer = DummyProducer::default();
 
-        let message = Message {
-            timestamp: 1337,
-            shared_resource_id: "foo".to_owned(),
-            app_feature: "app_feature".to_owned(),
-            usage_unit: UsageUnit::Bytes,
-            amount: 42,
-        };
-        producer.send(message).unwrap();
+        producer.send("foo".as_bytes().to_vec()).unwrap();
 
-        let Message {
-            timestamp,
-            shared_resource_id,
-            app_feature,
-            usage_unit,
-            amount,
-        } = producer.messages.pop().unwrap();
-
-        assert_eq!(timestamp, 1337);
-        assert_eq!(shared_resource_id, "foo");
-        assert_eq!(app_feature, "app_feature");
-        assert!(matches!(usage_unit, UsageUnit::Bytes));
-        assert_eq!(amount, 42);
+        assert_eq!(producer.messages.pop().as_deref(), Some("foo".as_bytes()));
+        assert!(producer.messages.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Reworks the API a bit, this is a breaking change, though the change on the API surface should be very minimal (only `KafkaConfig`).

* Adds the error as a GAT to the `Produce` trait. The error type changes per producer, this change makes it possible to actually have a different error type.
* Moves all Kafka related code into the Kafka module. Relay has a build mode to build without Kafka, there is a need to actually build the library without that dependency. Maybe the future should be enabled by default, but I opted not to enable it.
* Simplifies Dummy Producer (no need for Rc/RefCell), this was just not necessary in the code, non lexical lifetimes make this obsolete.
* The topic is no longer associated with the accountant, only the Kafka producer needs to know the topic. Also rustified the Kafka config to use the struct literal syntax and `..Default::default()`
* Producer now takes a message instead of bytes, in order for the Producer to choose the transport protocol and format.
* Implement Producer for all smart pointers via `DerefMut`

Supersedes: #6 #7 

The changes are motivated by features needed for Relay, we can keep the PR open until I finished the Relay implementation and group all changes together in this PR.