### PR TITLE
ref: Expose the message in the producer callback

### DIFF
--- a/examples/simple_produce.rs
+++ b/examples/simple_produce.rs
@@ -1,7 +1,7 @@
 extern crate sentry_usage_accountant;
 
 use clap::Parser;
-use sentry_usage_accountant::{KafkaConfig, KafkaProducer, Producer};
+use sentry_usage_accountant::{KafkaConfig, KafkaProducer, Message, Producer, UsageUnit};
 use std::collections::HashMap;
 
 #[derive(Parser, Debug)]
@@ -30,7 +30,13 @@ fn main() {
     };
     let mut producer = KafkaProducer::new(kafka_config);
 
-    producer
-        .send("hello world".as_bytes().to_vec())
-        .expect("failed to produce message");
+    let message = Message {
+        timestamp: 123,
+        shared_resource_id: "foo".to_owned(),
+        app_feature: "bar".to_owned(),
+        usage_unit: UsageUnit::Bytes,
+        amount: 42,
+    };
+
+    producer.send(&message).expect("failed to produce message");
 }

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 use tracing::{event, Level};
 
-use crate::Producer;
+use crate::{Message, Producer};
 
 const DEFAULT_TOPIC_NAME: &str = "shared-resources-usage";
 
@@ -90,11 +90,12 @@ pub enum KafkaProducerError {
 impl Producer for KafkaProducer {
     type Error = KafkaProducerError;
 
-    fn send(&mut self, payload: Vec<u8>) -> Result<(), Self::Error> {
+    fn send(&mut self, message: &Message) -> Result<(), Self::Error> {
+        let payload = message.serialize();
         let record: BaseRecord<'_, [u8], [u8]> = BaseRecord::to(&self.topic).payload(&payload);
         self.producer
             .send(record)
-            .map_err(|(error, _message)| KafkaProducerError::SendFailed(error))
+            .map_err(|(error, _)| KafkaProducerError::SendFailed(error))
     }
 }
 


### PR DESCRIPTION
In Relay I need access to the message in order to emit it as a datadog metric. This exposes the message but still keeps the serialization opaque.

#skip-changelog