### PR TITLE
build(deps): Relax rdkafka range to include 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ kafka = ["dep:rdkafka"]
 
 [dependencies]
 chrono = "0.4.31"
-rdkafka = { version = ">=0.29.0, <0.38.0", optional = true }
+rdkafka = { version = ">=0.29.0, <0.39.0", optional = true }
 thiserror = "1.0"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.93"


### PR DESCRIPTION
To allow snuba to update to 0.38 without having to pull in two separate versions.